### PR TITLE
Add ability to use multiple instances of middleware

### DIFF
--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -84,9 +84,15 @@ module Rack
 
     attr_reader :configuration
 
-    def initialize(app)
+    def initialize(app, &block)
       @app = app
-      @configuration = self.class.configuration
+      @configuration =
+        if block_given?
+          configuration = Configuration.new
+          configuration.instance_exec(&block)
+        else
+          self.class.configuration
+        end
     end
 
     def call(env)


### PR DESCRIPTION
This can be used as:
```ruby
use Rack::Attack do
  ...
  throttle("requests by ip", limit: 5, period: 2) do |request|
    request.ip
  end

  blocklist("block all access to admin") do |request|
    request.path.start_with?("/admin")
  end

  self.blocklisted_response = lambda do |env|
    [503, {}, ['Blocked']]
  end
  ...
end
```

The code is a little bit more complicated than it should be as I'm not broke old style of reopening `Rack::Attack`. I would prefer to remain only new style of configuring, but then this will force all gem users to update their `Rack::Attack` settings and recently added feature of using middleware automatically would not make sense. Maybe this makes more sense for 7.0 release?

New tests and documentation are missing - would add them after agreeing on implementation. 

Closes #178 