### PR TITLE
Expose Fail2Ban/Allow2Ban match_discriminator to blocklist

### DIFF
--- a/lib/rack/attack/blocklist.rb
+++ b/lib/rack/attack/blocklist.rb
@@ -7,6 +7,15 @@ module Rack
         super
         @type = :blocklist
       end
+
+      private
+
+      def add_additional_matched_data(request)
+        if (data = Thread.current[:rack_attack_matched_data])
+          request.env["rack.attack.match_discriminator"] = data[:match_discriminator]
+          Thread.current[:rack_attack_matched_data] = nil
+        end
+      end
     end
   end
 end

--- a/lib/rack/attack/check.rb
+++ b/lib/rack/attack/check.rb
@@ -15,10 +15,15 @@ module Rack
           if match
             request.env["rack.attack.matched"] = name
             request.env["rack.attack.match_type"] = type
+            add_additional_matched_data(request)
             Rack::Attack.instrument(request)
           end
         end
       end
+
+      private
+
+      def add_additional_matched_data(_request); end
     end
   end
 end

--- a/lib/rack/attack/fail2ban.rb
+++ b/lib/rack/attack/fail2ban.rb
@@ -9,12 +9,15 @@ module Rack
           findtime  = options[:findtime]  or raise ArgumentError, "Must pass findtime option"
           maxretry  = options[:maxretry]  or raise ArgumentError, "Must pass maxretry option"
 
+          banned = false
           if banned?(discriminator)
-            # Return true for blocklist
-            true
+            banned = true
           elsif yield
-            fail!(discriminator, bantime, findtime, maxretry)
+            banned = fail!(discriminator, bantime, findtime, maxretry)
           end
+
+          Thread.current[:rack_attack_matched_data] = { match_discriminator: discriminator } if banned
+          banned
         end
 
         def reset(discriminator, options)


### PR DESCRIPTION
Using thread locals is the simplest implementation in this case I can think of.

Closes #200 