### PR TITLE
Configure middleware position in Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ You can disable it permanently (like for specific environment) or temporarily (c
 Rack::Attack.enabled = false
 ```
 
+You can also tweak its position in the Rack middleware stack.
+
+```ruby
+# in config/application.rb
+
+# by index
+config.rack_attack.middleware_position = 0
+
+# relative to another middleware
+config.rack_attack.middleware_position = {
+  before: AnotherMiddleware, # optional
+  after: YetAnotherMiddleware # optional
+} 
+```
+
 b) For __rack__ applications:
 
 ```ruby

--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -13,8 +13,6 @@ require 'rack/attack/store_proxy/redis_store_proxy'
 require 'rack/attack/store_proxy/redis_cache_store_proxy'
 require 'rack/attack/store_proxy/active_support_redis_store_proxy'
 
-require 'rack/attack/railtie' if defined?(::Rails)
-
 module Rack
   class Attack
     class Error < StandardError; end
@@ -129,3 +127,5 @@ module Rack
     end
   end
 end
+
+require 'rack/attack/railtie' if defined?(::Rails)

--- a/lib/rack/attack/configuration.rb
+++ b/lib/rack/attack/configuration.rb
@@ -20,7 +20,8 @@ module Rack
       end
 
       attr_reader :safelists, :blocklists, :throttles, :anonymous_blocklists, :anonymous_safelists
-      attr_accessor :blocklisted_callback, :throttled_callback, :throttled_response_retry_after_header
+      attr_accessor :blocklisted_callback, :middleware_position, :throttled_callback,
+                    :throttled_response_retry_after_header
 
       attr_reader :blocklisted_response, :throttled_response # Keeping these for backwards compatibility
 

--- a/lib/rack/attack/railtie.rb
+++ b/lib/rack/attack/railtie.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require "rails"
-
 module Rack
   class Attack
     class Railtie < ::Rails::Railtie
       # Initialize rack-attack own configuration object in application config
-      config.rack_attack = ActiveSupport::OrderedOptions.new
+      config.rack_attack = Rack::Attack.configuration
 
       # Set Rack middleware position. By default it is unset.
       config.rack_attack.middleware_position = nil

--- a/lib/rack/attack/railtie.rb
+++ b/lib/rack/attack/railtie.rb
@@ -1,10 +1,36 @@
 # frozen_string_literal: true
 
+require "rails"
+
 module Rack
   class Attack
     class Railtie < ::Rails::Railtie
+      # Initialize rack-attack own configuration object in application config
+      config.rack_attack = ActiveSupport::OrderedOptions.new
+
+      # Set Rack middleware position. By default it is unset.
+      config.rack_attack.middleware_position = nil
+
       initializer "rack-attack.middleware" do |app|
-        app.middleware.use(Rack::Attack)
+        insert_middleware_at(app, app.config.rack_attack.middleware_position)
+      end
+
+      private
+
+      def insert_middleware_at(app, position)
+        if position.nil?
+          app.middleware.use(Rack::Attack)
+        elsif position.is_a?(Integer)
+          app.middleware.insert_before(position, Rack::Attack)
+        elsif position.is_a?(Hash)
+          app.middleware.insert_before(position[:before], Rack::Attack) if position.key?(:before)
+          app.middleware.insert_after(position[:after], Rack::Attack) if position.key?(:after)
+        else
+          raise <<~ERROR
+            The middleware position you have set is invalid. Please be sure
+            `config.rack_attack.middleware_position` is set up correctly.
+          ERROR
+        end
       end
     end
   end

--- a/spec/acceptance/rails_middleware_spec.rb
+++ b/spec/acceptance/rails_middleware_spec.rb
@@ -12,9 +12,45 @@ if defined?(Rails)
       end
     end
 
-    it "is used by default" do
+    it "is placed at the end by default" do
       @app.initialize!
-      assert @app.middleware.include?(Rack::Attack)
+
+      assert @app.middleware.last == Rack::Attack
+    end
+
+    it "is placed at a specific index when the configured position is an integer" do
+      old_config = @app.config.rack_attack.clone
+      @app.config.rack_attack.middleware_position = 0
+
+      @app.initialize!
+
+      assert @app.middleware[0] == Rack::Attack
+
+      @app.config.rack_attack = old_config
+    end
+
+    it "is placed before a specific middleware when configured with :before" do
+      old_config = @app.config.rack_attack.clone
+      @app.config.rack_attack.middleware_position = { before: Rack::Runtime }
+
+      @app.initialize!
+
+      middlewares = @app.middleware.middlewares
+      assert middlewares.index(Rack::Attack) == middlewares.index(Rack::Runtime) - 1
+
+      @app.config.rack_attack = old_config
+    end
+
+    it "is placed after a specific middleware when configured with :after" do
+      old_config = @app.config.rack_attack.clone
+      @app.config.rack_attack.middleware_position = { after: Rack::Runtime }
+
+      @app.initialize!
+
+      middlewares = @app.middleware.middlewares
+      assert middlewares.index(Rack::Attack) == middlewares.index(Rack::Runtime) + 1
+
+      @app.config.rack_attack = old_config
     end
   end
 end


### PR DESCRIPTION
Why:

* The position of a middleware in the Rack attack has consequences. For
  instance, any instrumentation middleware like [Skylight] will measure
  and capture what happens in the middlewares below it, but not on those
  above.

  The current implementation forces the rack-attack middleware to always
  be appended to the list when initializing Rails, making it the last on
  the list when added, but often others will be added afterwards.

  While this behaviour is perfectly suitable by default, there are
  situations where one might need to control where the middleware is on
  the list. Given the lack of configuration points to tweak this
  behaviour, currently the only way to achieve this is to add the
  middleware again at the top. This results in a duplication of the
  `Rack::Attack` middleware in the stack.

This change addresses the need by:

* Shamelessly copying the approach followed by [skylight-ruby], where
  the Railtie initializes a configuration object that can be set up in
  `config/application.rb`, thus allowing the position of the middleware
  to be tweaked.

[Skylight]: https://skylight.io
[skylight-ruby]: https://github.com/skylightio/skylight-ruby