### PR TITLE
Rescue InvalidParameterError with 400 Response

### DIFF
--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -22,6 +22,15 @@ module Rack
     class MissingStoreError < Error; end
     class IncompatibleStoreError < Error; end
 
+    INVALID_PARAMETER_ERRORS = if defined?(Rack::RELEASE)
+                                 [
+                                   Rack::Utils::InvalidParameterError,
+                                   Rack::QueryParser::InvalidParameterError
+                                 ]
+                               else
+                                 []
+                               end
+
     autoload :Check,                'rack/attack/check'
     autoload :Throttle,             'rack/attack/throttle'
     autoload :Safelist,             'rack/attack/safelist'
@@ -126,7 +135,7 @@ module Rack
         configuration.tracked?(request)
         @app.call(env)
       end
-    rescue Rack::Utils::InvalidParameterError, Rack::QueryParser::InvalidParameterError
+    rescue *INVALID_PARAMETER_ERRORS
       [400, {}, []]
     end
   end

--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -126,6 +126,8 @@ module Rack
         configuration.tracked?(request)
         @app.call(env)
       end
+    rescue Rack::Utils::InvalidParameterError, Rack::QueryParser::InvalidParameterError
+      [400, {}, []]
     end
   end
 end

--- a/spec/rack_attack_spec.rb
+++ b/spec/rack_attack_spec.rb
@@ -5,6 +5,20 @@ require_relative 'spec_helper'
 describe 'Rack::Attack' do
   it_allows_ok_requests
 
+  describe 'call' do
+    it 'responds with 400 when invalid parameter error is raised' do
+      app = Class.new do
+        def call(*)
+          raise Rack::QueryParser::InvalidParameterError
+        end
+      end
+      middleware = Rack::Attack.new(app.new)
+      env = { 'PATH_INFO' => '/' }
+
+      _(middleware.call(env)).must_equal [400, {}, []]
+    end
+  end
+
   describe 'normalizing paths' do
     before do
       Rack::Attack.blocklist("banned_path") { |req| req.path == '/foo' }

--- a/spec/rack_attack_spec.rb
+++ b/spec/rack_attack_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'spec_helper'
+require 'rack/query_parser'
 
 describe 'Rack::Attack' do
   it_allows_ok_requests

--- a/spec/rack_attack_spec.rb
+++ b/spec/rack_attack_spec.rb
@@ -1,22 +1,24 @@
 # frozen_string_literal: true
 
 require_relative 'spec_helper'
-require 'rack/query_parser'
+require 'rack/query_parser' if defined?(Rack::RELEASE)
 
 describe 'Rack::Attack' do
   it_allows_ok_requests
 
-  describe 'call' do
-    it 'responds with 400 when invalid parameter error is raised' do
-      app = Class.new do
-        def call(*)
-          raise Rack::QueryParser::InvalidParameterError
+  if defined?(Rack::RELEASE)
+    describe 'call' do
+      it 'responds with 400 when invalid parameter error is raised' do
+        app = Class.new do
+          def call(*)
+            raise Rack::QueryParser::InvalidParameterError
+          end
         end
-      end
-      middleware = Rack::Attack.new(app.new)
-      env = { 'PATH_INFO' => '/' }
+        middleware = Rack::Attack.new(app.new)
+        env = { 'PATH_INFO' => '/' }
 
-      _(middleware.call(env)).must_equal [400, {}, []]
+        _(middleware.call(env)).must_equal [400, {}, []]
+      end
     end
   end
 


### PR DESCRIPTION
The documentation for [Rack::QueryParser#parse_nested_query][] states that when encountering an `InvalidParameterError`, the middleware or application should just return an empty 400 response to indicate that the request will not be processed, rather than allowing the exception to throw a 500 error. This happens in [Rails][], so when a particular request/IP combo is being thwarted by `Rack::Attack`, you'll still get an error that ends up being a bunch of noise in your error monitoring or logging system. To address this, `rescue` the errors that could cause this particular situation and respond with a clean 400 error.

[Rack::QueryParser#parse_nested_query]: https://www.rubydoc.info/github/rack/rack/Rack%2FQueryParser:parse_nested_query
[Rails]: https://github.com/rails/rails/blob/fdd5894aa985651fb99e0ef1c2d3f3f604b2f659/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb#L23