### PR TITLE
Lock rubocop-ast version.

### DIFF
--- a/rack-attack.gemspec
+++ b/rack-attack.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack-test', "~> 1.0"
   s.add_development_dependency 'rake', "~> 13.0"
   s.add_development_dependency "rubocop", "0.84.0"
+  s.add_development_dependency "rubocop-ast", "~> 0.3.0"
   s.add_development_dependency "rubocop-performance", "~> 1.5.0"
   s.add_development_dependency "timecop", "~> 0.9.1"
 


### PR DESCRIPTION
- newer version seems to not be compatible with used rubocop version

This should fix CI for now, later we can upgrade whole rubocop stack as well.