### PR TITLE
Fix Ruby 2.7 kwargs warning in RedisCacheStoreProxy

### DIFF
--- a/lib/rack/attack/store_proxy/redis_cache_store_proxy.rb
+++ b/lib/rack/attack/store_proxy/redis_cache_store_proxy.rb
@@ -10,7 +10,7 @@ module Rack
           store.class.name == "ActiveSupport::Cache::RedisCacheStore"
         end
 
-        def increment(name, amount = 1, options = {})
+        def increment(name, amount = 1, **options)
           # RedisCacheStore#increment ignores options[:expires_in].
           #
           # So in order to workaround this we use RedisCacheStore#write (which sets expiration) to initialize


### PR DESCRIPTION
fix https://github.com/rack/rack-attack/issues/508