### PR TITLE
Use single quotes in example configuration

### DIFF
--- a/docs/example_configuration.md
+++ b/docs/example_configuration.md
@@ -59,7 +59,7 @@ class Rack::Attack
   # throttle logins for another user and force their login requests to be
   # denied, but that's not very common and shouldn't happen to you. (Knock
   # on wood!)
-  throttle("logins/email", limit: 5, period: 20.seconds) do |req|
+  throttle('logins/email', limit: 5, period: 20.seconds) do |req|
     if req.path == '/login' && req.post?
       # Normalize the email, using the same logic as your authentication process, to
       # protect against rate limit bypasses. Return the normalized email if present, nil otherwise.


### PR DESCRIPTION
This updates the `logins/email` config to use single quotes, for consistency with the other examples in the example config.