### PR TITLE
Update readme documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,18 +315,18 @@ Note that `Rack::Attack.cache` is only used for throttling, allow2ban and fail2b
 Customize the response of blocklisted and throttled requests using an object that adheres to the [Rack app interface](http://www.rubydoc.info/github/rack/rack/file/SPEC).
 
 ```ruby
-Rack::Attack.blocklisted_callback = lambda do |request|
+Rack::Attack.blocklisted_response = lambda do |env|
   # Using 503 because it may make attacker think that they have successfully
   # DOSed the site. Rack::Attack returns 403 for blocklists by default
   [ 503, {}, ['Blocked']]
 end
 
-Rack::Attack.throttled_callback = lambda do |request|
+Rack::Attack.throttled_response = lambda do |env|
   # NB: you have access to the name and other data about the matched throttle
-  #  request.env['rack.attack.matched'],
-  #  request.env['rack.attack.match_type'],
-  #  request.env['rack.attack.match_data'],
-  #  request.env['rack.attack.match_discriminator']
+  #  env['rack.attack.matched'],
+  #  env['rack.attack.match_type'],
+  #  env['rack.attack.match_data'],
+  #  env['rack.attack.match_discriminator']
 
   # Using 503 because it may make attacker think that they have successfully
   # DOSed the site. Rack::Attack returns 429 for throttling by default


### PR DESCRIPTION
The `blocklisted_callback` and  `throttled_callback` are no longer available
and have been removed. The correct way to specify those callbacks are via
`blocklisted_response` and `throttled_response`.

Also those callbacks are now getting the `env` send as the argument instead
of the `request` object.