### PR TITLE
Add helper to generate response headers

### DIFF
--- a/lib/rack/attack/response_headers.rb
+++ b/lib/rack/attack/response_headers.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Rack
+  class Attack
+    class ResponseHeaders
+      # Attributes
+      attr_reader :count, :epoch_time, :limit, :period
+
+      def initialize(data)
+        @count = data[:count]
+        @epoch_time = data[:epoch_time]
+        @limit = data[:limit]
+        @period = data[:period]
+      end
+
+      # Access the epoch time as a time object.
+      #
+      # @return [Time]
+      def count_time
+        @count_time ||= Time.zone.at(epoch_time, in: 'UTC')
+      end
+
+      # Generate rate limit headers.
+      #
+      # @param include_limit [Boolean] - whethert to include the `X-RateLimit-Limit` header.
+      # @param include_remaining [Boolean] - whethert to include the `X-RateLimit-Remaining` header.
+      # @param include_reset [Boolean] - whethert to include the `X-RateLimit-Reset` header.
+      #
+      # @return [Hash]
+      def generate(include_limit: true, include_remaining: true, include_reset: true)
+        headers = {}
+        headers['X-RateLimit-Limit'] = limit.to_s if include_limit
+        headers['X-RateLimit-Remaining'] = remaining.to_s if include_remaining
+        headers['X-RateLimit-Reset'] = reset.iso8601 if include_reset
+        headers
+      end
+
+      # Calculate the number of requests remaining in the current rate limit
+      # window.
+      #
+      # @return [Integer]
+      def remaining
+        @remaining ||= limit - count
+      end
+
+      # Calculate the time at which the current rate limit window resets in UTC.
+      # https://github.com/rack/rack-attack/pull/191#issuecomment-237295523
+      #
+      # @return [Time]
+      def reset
+        @reset ||= count_time + (period - count_time.to_i % period)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Provides a handy helper to help generate the response headers either based off throttle data e.g. `env['rack.attack.match_data']` or even `env['rack.attack.throttle_data'][throttle_name]`. I don't know if this is worth being included in the library but I figured sharing it wouldn't hurt 🤷🏽‍♂️ and it might save someone else time.

To note, this is related to the discussion in https://github.com/rack/rack-attack/pull/191 (and maybe https://github.com/rack/rack-attack/issues/29) but since it's just a helper, it's all opt-in i.e. no opinions on whether you should generate the headers or not (or even where) ... you choose to use the helper if/when/where you want it.

#### Usage Examples

It can be used in the controller to set response headers (Rails example) ...

```ruby
module API
  class BaseController < ApplicationController
    after_action :set_rate_limit_headers!

    def set_rate_limit_headers!
      throttle_data = request.env['rack.attack.throttle_data'][throttle_name]
      options = [include_limit: true, include_remaining: true, include_reset: true]
      rate_limit_headers = Rack::Attack::ResponseHeaders.new(throttle_data).generate(*options)
      rate_limit_headers.each { |name, value| response.set_header(name, value) }
    end
  end
end
```

Or it can be used in `throttled_response` ...

```ruby
# Return rate limit data that's helpful for well-behaved clients such as how
# many seconds to wait until they can start sending requests again.
Rack::Attack.throttled_response_retry_after_header = true
Rack::Attack.throttled_response = lambda do |env|
  throttle_data = env['rack.attack.match_data']
  options = [include_limit: true, include_remaining: false, include_reset: true]
  headers = Rack::Attack::ResponseHeaders.new(throttle_data).generate(*options)
  headers['X-RateLimit-Remaining'] = '0'
  response = {
    errors: [
      {
        status: '429',
        title: 'Too Many Requests'
      }
    ]
  }.to_json

  [429, headers, [response]]
end
```