### PR TITLE
Notify discriminator for tracked requests

### DIFF
--- a/lib/rack/attack/check.rb
+++ b/lib/rack/attack/check.rb
@@ -15,6 +15,7 @@ module Rack
         block.call(request).tap do |match|
           if match
             request.env["rack.attack.matched"] = name
+            request.env['rack.attack.match_discriminator'] = match
             request.env["rack.attack.match_type"] = type
             Rack::Attack.instrument(request)
           end


### PR DESCRIPTION
Hi!

I am working on the monitoring solution for rack attack [here](https://github.com/dsalahutdinov/yabeda-rack-attack). It listens to events and [increments specific counters](https://github.com/dsalahutdinov/yabeda-rack-attack/blob/master/lib/yabeda/rack/attack/notifier.rb#L31-L33) for any rule type (throttle, blacklist, whitelist, and track).

For now, if I write the following track rule - I will have any requests matching. But there would not be discriminator passed to the event. I think tracking requests in context is an in-demand feature. It will be great to pass additional information about the block-result value.

```
Rack::Attack.track('requests by user agent family') do |req|
  UserAgentParser.parse(req.user_agent).family
end
```

Here is how nice we can visualize the data, collected in context of result:

<img width="1370" alt="Screenshot 2021-06-07 at 23 49 05" src="https://user-images.githubusercontent.com/204024/121074074-c9fde100-c7ec-11eb-9542-bdbc2623a3d3.png">

I think this feature opens up new opportunities to do initial research before setting up any rule for production. We can first track queries for some time to collect some statistics for proposal rule this way. Great example:

```
Rack::Attack.track('tracks requests per user') do |req|
  req.env['warden']&.user&.id
end
```
Then collect any statistics to analyze how many requests every user does.

Then implement throttling with something like this:
```
Rack::Attack.throttle('requests per user', limit: 10, period: 1.minute) do |req|
  req.env['warden']&.user&.id
end
```

My proposal pull-request keeps the "tracks" feature logic the same and is fully compatible for all the listeners.