### PR TITLE
Update README to mention .clear_configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ for more on how to do this.
 
 ### Test case isolation
 
-`Rack::Attack.reset!` can be used in your test suite to clear any Rack::Attack state between different test cases.
+`Rack::Attack.reset!` can be used in your test suite to clear any Rack::Attack state between different test cases. If you're testing blocklist and safelist configurations, consider using `Rack::Attack.clear_configuration` to unset the values for those lists between test cases.
 
 ## How it works
 


### PR DESCRIPTION
Adds a line to the `Test case isolation` section of `README.md` about `.clear_configuration`. This manifested after I ran into the issue described in #561 with blocklist and safelist states not being cleared between test cases using `.reset!`. 