### PR TITLE
Include LICENSE in gem build

### DIFF
--- a/rack-attack.gemspec
+++ b/rack-attack.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = "A rack middleware for throttling and blocking abusive requests"
   s.email = "aaron@ktheory.com"
 
-  s.files = Dir.glob("{bin,lib}/**/*") + %w(Rakefile README.md)
+  s.files = Dir.glob("{bin,lib}/**/*") + %w(Rakefile README.md LICENSE)
   s.homepage = 'https://github.com/rack/rack-attack'
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]


### PR DESCRIPTION
Hi 👋 

Including the LICENSE in gem builds is helpful when generating a report including licenses from all your dependencies.
`rack/rack` [does it](https://github.com/rack/rack/blob/c1e5fbbb59101c039e8b657c8052e152c572d5ac/rack.gemspec#L20-L21) for instance.