### PR TITLE
fix: Fix redis-rb 4.6.0 deprecation warnings

### DIFF
--- a/lib/rack/attack/store_proxy/redis_proxy.rb
+++ b/lib/rack/attack/store_proxy/redis_proxy.rb
@@ -32,9 +32,9 @@ module Rack
 
         def increment(key, amount, options = {})
           rescuing do
-            pipelined do
-              incrby(key, amount)
-              expire(key, options[:expires_in]) if options[:expires_in]
+            pipelined do |redis|
+              redis.incrby(key, amount)
+              redis.expire(key, options[:expires_in]) if options[:expires_in]
             end.first
           end
         end


### PR DESCRIPTION
Redis 4.6.0 deprecated calling commands on `Redis` inside `#pipelined`:

    redis.pipelined do
      redis.get("key")
    end

The above should be:

    redis.pipelined do |pipeline|
      pipeline.get("key")
    end

See: https://github.com/redis/redis-rb/pull/1059