### PR TITLE
Replace git.io URL

### DIFF
--- a/lib/rack/attack/cache.rb
+++ b/lib/rack/attack/cache.rb
@@ -62,7 +62,7 @@ module Rack
 
       def key_and_expiry(unprefixed_key, period)
         @last_epoch_time = Time.now.to_i
-        # Add 1 to expires_in to avoid timing error: https://git.io/i1PHXA
+        # Add 1 to expires_in to avoid timing error: https://github.com/rack/rack-attack/pull/85
         expires_in = (period - (@last_epoch_time % period) + 1).to_i
         ["#{prefix}:#{(@last_epoch_time / period).to_i}:#{unprefixed_key}", expires_in]
       end

--- a/lib/rack/attack/path_normalizer.rb
+++ b/lib/rack/attack/path_normalizer.rb
@@ -4,7 +4,9 @@ module Rack
   class Attack
     # When using Rack::Attack with a Rails app, developers expect the request path
     # to be normalized. In particular, trailing slashes are stripped.
-    # (See https://git.io/v0rrR for implementation.)
+    # (See
+    # https://github.com/rails/rails/blob/f8edd20/actionpack/lib/action_dispatch/journey/router/utils.rb#L5-L22
+    # for implementation.)
     #
     # Look for an ActionDispatch utility class that Rails folks would expect
     # to normalize request paths. If unavailable, use a fallback class that


### PR DESCRIPTION
Hi,

git.io URL has been deprecated, and it will stop redirecting on April 29, 2022.

For more detail:
https://github.blog/changelog/2022-04-25-git-io-deprecation/