### PR TITLE
Add development dependency on rack-session

### DIFF
--- a/rack-attack.gemspec
+++ b/rack-attack.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', "~> 5.11"
   s.add_development_dependency "minitest-stub-const", "~> 0.6"
   s.add_development_dependency 'rack-test', "~> 1.0"
+  s.add_development_dependency 'rack-session'
   s.add_development_dependency 'rake', "~> 13.0"
   s.add_development_dependency "rubocop", "0.89.1"
   s.add_development_dependency "rubocop-performance", "~> 1.5.0"


### PR DESCRIPTION
rack-session has been split out of rack, and it's necessary for
one of the Rails middleware specs to pass.