### PR TITLE
Update changelog for v6.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [6.7.0] - 2023-07-26
+
+- Replace git.io URL by @kyoshidajp in #579
+- test: update rack-test to v2 from v1 by @grzuy in #587
+- Update example description to not suggest using a deprecated method by @MaksimAbramchuk in #589
+- Add note about cache stores and in-memory caches. by @nateberkopec in #604
+- ci: tests against redis gem v5 by @grzuy in #612
+- Support rack 3 by @ioquatix in #586
+- Gem release management. by @ioquatix in #614
+
 ## [6.6.1] - 2022-04-14
 
 ### Fixed


### PR DESCRIPTION
Content of `CHANGELOG.md` based on https://github.com/rack/rack-attack/releases/tag/v6.7.0.

A possible alternative would be to change this line at the top of `CHANGELOG.md`:

> All notable changes to this project will be documented in this file.

To something like:

> All changes after v6.6.1 will be documented in the relevant release note.

Addresses #616.