### PR TITLE
Rename MiniTest -> Minitest

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ safe_require "redis"
 safe_require "redis-activesupport"
 safe_require "redis-store"
 
-class MiniTest::Spec
+class Minitest::Spec
   include Rack::Test::Methods
 
   before do


### PR DESCRIPTION
The latest version of minitest dropped the [ancient MiniTest compatibility layer][1], so we need to use the newer module name, `Minitest`.

[1]: https://github.com/minitest/minitest/blob/master/History.rdoc#label-5.19.0+-2F+2023-07-26