### PR TITLE
Changelog changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,6 +281,7 @@ so your custom code is less prone to race conditions ([#282](https://github.com/
  - Extract mandatory options to constants
 
 
+[6.7.0]: https://github.com/rack/rack-attack/compare/v6.6.1...v6.7.0/
 [6.6.1]: https://github.com/rack/rack-attack/compare/v6.6.0...v6.6.1/
 [6.6.0]: https://github.com/rack/rack-attack/compare/v6.5.0...v6.6.0/
 [6.5.0]: https://github.com/rack/rack-attack/compare/v6.4.0...v6.5.0/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+This file will no longer be updated - all changes after v6.7.0 will only be documented in the relevant release note.
 
 ## [6.7.0] - 2023-07-26
 


### PR DESCRIPTION
* Add missing reference to `CHANGELOG.md` for v6.7.0.
* Explain that `CHANGELOG.md` will no longer be updated.