### PR TITLE
Update rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,7 +56,6 @@ Security:
 
 Style/BlockDelimiters:
   Enabled: true
-  IgnoredMethods: [] # Workaround rubocop bug: https://github.com/rubocop-hq/rubocop/issues/6179
 
 Style/ClassAndModuleChildren:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 require:
+  - rubocop-minitest
   - rubocop-performance
 
 inherit_mode:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop-minitest
   - rubocop-performance
+  - rubocop-rake
 
 inherit_mode:
   merge:

--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -17,8 +17,11 @@ require 'rack/attack/railtie' if defined?(::Rails)
 module Rack
   class Attack
     class Error < StandardError; end
+
     class MisconfiguredStoreError < Error; end
+
     class MissingStoreError < Error; end
+
     class IncompatibleStoreError < Error; end
 
     autoload :Check,                'rack/attack/check'

--- a/lib/rack/attack/base_proxy.rb
+++ b/lib/rack/attack/base_proxy.rb
@@ -11,6 +11,7 @@ module Rack
         end
 
         def inherited(klass)
+          super
           proxies << klass
         end
 

--- a/rack-attack.gemspec
+++ b/rack-attack.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rubocop", "1.12.1"
   s.add_development_dependency "rubocop-minitest", "~> 0.11.1"
   s.add_development_dependency "rubocop-performance", "~> 1.5.0"
+  s.add_development_dependency "rubocop-rake", "~> 0.5.1"
   s.add_development_dependency "timecop", "~> 0.9.1"
 
   # byebug only works with MRI

--- a/rack-attack.gemspec
+++ b/rack-attack.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack-test', "~> 2.0"
   s.add_development_dependency 'rake', "~> 13.0"
   s.add_development_dependency "rubocop", "1.12.1"
+  s.add_development_dependency "rubocop-minitest", "~> 0.11.1"
   s.add_development_dependency "rubocop-performance", "~> 1.5.0"
   s.add_development_dependency "timecop", "~> 0.9.1"
 

--- a/rack-attack.gemspec
+++ b/rack-attack.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', "~> 13.0"
   s.add_development_dependency "rubocop", "1.12.1"
   s.add_development_dependency "rubocop-minitest", "~> 0.11.1"
-  s.add_development_dependency "rubocop-performance", "~> 1.5.0"
+  s.add_development_dependency "rubocop-performance", "~> 1.10.2"
   s.add_development_dependency "rubocop-rake", "~> 0.5.1"
   s.add_development_dependency "timecop", "~> 0.9.1"
 

--- a/rack-attack.gemspec
+++ b/rack-attack.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest-stub-const", "~> 0.6"
   s.add_development_dependency 'rack-test', "~> 2.0"
   s.add_development_dependency 'rake', "~> 13.0"
-  s.add_development_dependency "rubocop", "0.89.1"
+  s.add_development_dependency "rubocop", "1.12.1"
   s.add_development_dependency "rubocop-performance", "~> 1.5.0"
   s.add_development_dependency "timecop", "~> 0.9.1"
 

--- a/spec/acceptance/cache_store_config_for_fail2ban_spec.rb
+++ b/spec/acceptance/cache_store_config_for_fail2ban_spec.rb
@@ -79,7 +79,7 @@ describe "Cache store config when using fail2ban" do
   end
 
   it "works with any object that responds to #read, #write and #increment" do
-    FakeStore = Class.new do
+    fake_store_class = Class.new do
       attr_accessor :backend
 
       def initialize
@@ -100,7 +100,7 @@ describe "Cache store config when using fail2ban" do
       end
     end
 
-    Rack::Attack.cache.store = FakeStore.new
+    Rack::Attack.cache.store = fake_store_class.new
 
     get "/"
     assert_equal 200, last_response.status

--- a/spec/acceptance/extending_request_object_spec.rb
+++ b/spec/acceptance/extending_request_object_spec.rb
@@ -4,10 +4,8 @@ require_relative "../spec_helper"
 
 describe "Extending the request object" do
   before do
-    class Rack::Attack::Request
-      def authorized?
-        env["APIKey"] == "private-secret"
-      end
+    Rack::Attack::Request.define_method :authorized? do
+      env["APIKey"] == "private-secret"
     end
 
     Rack::Attack.blocklist("unauthorized requests") do |request|
@@ -17,9 +15,7 @@ describe "Extending the request object" do
 
   # We don't want the extension to leak to other test cases
   after do
-    class Rack::Attack::Request
-      remove_method :authorized?
-    end
+    Rack::Attack::Request.undef_method :authorized?
   end
 
   it "forbids request if blocklist condition is true" do

--- a/spec/rack_attack_request_spec.rb
+++ b/spec/rack_attack_request_spec.rb
@@ -5,10 +5,8 @@ require_relative 'spec_helper'
 describe 'Rack::Attack' do
   describe 'helpers' do
     before do
-      class Rack::Attack::Request
-        def remote_ip
-          ip
-        end
+      Rack::Attack::Request.define_method :remote_ip do
+        ip
       end
 
       Rack::Attack.safelist('valid IP') do |req|

--- a/spec/rack_attack_track_spec.rb
+++ b/spec/rack_attack_track_spec.rb
@@ -3,17 +3,19 @@
 require_relative 'spec_helper'
 
 describe 'Rack::Attack.track' do
-  class Counter
-    def self.incr
-      @counter += 1
-    end
+  let(:counter_class) do
+    Class.new do
+      def self.incr
+        @counter += 1
+      end
 
-    def self.reset
-      @counter = 0
-    end
+      def self.reset
+        @counter = 0
+      end
 
-    def self.check
-      @counter
+      def self.check
+        @counter
+      end
     end
   end
 
@@ -32,19 +34,19 @@ describe 'Rack::Attack.track' do
 
   describe "with a notification subscriber and two tracks" do
     before do
-      Counter.reset
+      counter_class.reset
       # A second track
       Rack::Attack.track("homepage") { |req| req.path == "/" }
 
       ActiveSupport::Notifications.subscribe("track.rack_attack") do |*_args|
-        Counter.incr
+        counter_class.incr
       end
 
       get "/"
     end
 
     it "should notify twice" do
-      _(Counter.check).must_equal 2
+      _(counter_class.check).must_equal 2
     end
   end
 


### PR DESCRIPTION
- Upgraded main `rubocop` gem
- Fixed one 1 warning message
- Fixed 6 offenses
- Added two extensions (`rubocop-minitest` and `rubocop-rake`) that were suggested by the `rubocop` command
- Upgraded `rubocop-performance`


TODO:
- check new cops which are disabled by default


Output of `rubocop` after upgrading the gem (without any other change):
![image](https://github.com/rack/rack-attack/assets/6373536/8cf0e93c-0d91-40cb-bfb1-8965247ae933)

Output of `rubocop` after all changes in this PR:
![image](https://github.com/rack/rack-attack/assets/6373536/6957cc47-7c29-40a1-b12e-5377b0b70d44)
