### PR TITLE
Fix #588 don't fail if request.ip is missing

### DIFF
--- a/lib/rack/attack/configuration.rb
+++ b/lib/rack/attack/configuration.rb
@@ -61,11 +61,11 @@ module Rack
       end
 
       def blocklist_ip(ip_address)
-        @anonymous_blocklists << Blocklist.new { |request| IPAddr.new(ip_address).include?(IPAddr.new(request.ip)) }
+        @anonymous_blocklists << Blocklist.new { |request| IPAddr.new(ip_address).include?(IPAddr.new(*request.ip)) }
       end
 
       def safelist_ip(ip_address)
-        @anonymous_safelists << Safelist.new { |request| IPAddr.new(ip_address).include?(IPAddr.new(request.ip)) }
+        @anonymous_safelists << Safelist.new { |request| IPAddr.new(ip_address).include?(IPAddr.new(*request.ip)) }
       end
 
       def throttle(name, options, &block)

--- a/lib/rack/attack/configuration.rb
+++ b/lib/rack/attack/configuration.rb
@@ -61,11 +61,15 @@ module Rack
       end
 
       def blocklist_ip(ip_address)
-        @anonymous_blocklists << Blocklist.new { |request| IPAddr.new(ip_address).include?(IPAddr.new(*request.ip)) }
+        @anonymous_blocklists << Blocklist.new do |request|
+          request.ip && !request.ip.empty? && IPAddr.new(ip_address).include?(IPAddr.new(request.ip))
+        end
       end
 
       def safelist_ip(ip_address)
-        @anonymous_safelists << Safelist.new { |request| IPAddr.new(ip_address).include?(IPAddr.new(*request.ip)) }
+        @anonymous_safelists << Safelist.new do |request|
+          request.ip && !request.ip.empty? && IPAddr.new(ip_address).include?(IPAddr.new(request.ip))
+        end
       end
 
       def throttle(name, options, &block)

--- a/spec/acceptance/blocking_ip_spec.rb
+++ b/spec/acceptance/blocking_ip_spec.rb
@@ -14,7 +14,7 @@ describe "Blocking an IP" do
   end
 
   it "succeeds if IP doesn't match" do
-    get "/", {}, "REMOTE_ADDR" => "5.6.7.8"
+    get "/", {}, "REMOTE_ADDR" => ""
 
     assert_equal 200, last_response.status
   end

--- a/spec/acceptance/blocking_ip_spec.rb
+++ b/spec/acceptance/blocking_ip_spec.rb
@@ -14,6 +14,12 @@ describe "Blocking an IP" do
   end
 
   it "succeeds if IP doesn't match" do
+    get "/", {}, "REMOTE_ADDR" => "5.6.7.8"
+
+    assert_equal 200, last_response.status
+  end
+
+  it "succeeds if IP is missing" do
     get "/", {}, "REMOTE_ADDR" => ""
 
     assert_equal 200, last_response.status

--- a/spec/acceptance/safelisting_ip_spec.rb
+++ b/spec/acceptance/safelisting_ip_spec.rb
@@ -12,6 +12,12 @@ describe "Safelist an IP" do
   end
 
   it "forbids request if blocklist condition is true and safelist is false" do
+    get "/admin", {}, "REMOTE_ADDR" => "1.2.3.4"
+
+    assert_equal 403, last_response.status
+  end
+
+  it "forbids request if blocklist condition is true and safelist is false (missing IP)" do
     get "/admin", {}, "REMOTE_ADDR" => ""
 
     assert_equal 403, last_response.status

--- a/spec/acceptance/safelisting_ip_spec.rb
+++ b/spec/acceptance/safelisting_ip_spec.rb
@@ -12,7 +12,7 @@ describe "Safelist an IP" do
   end
 
   it "forbids request if blocklist condition is true and safelist is false" do
-    get "/admin", {}, "REMOTE_ADDR" => "1.2.3.4"
+    get "/admin", {}, "REMOTE_ADDR" => ""
 
     assert_equal 403, last_response.status
   end


### PR DESCRIPTION
From https://github.com/rack/rack-attack/issues/588 we can see that if for some reason the `request.ip` is missing, `rack-attack` will try to do `IPAddr.new(nil)` which raises `*** IPAddr::AddressFamilyError Exception: address family must be specified`.

With this PR we only call IPAddr.new if we have a not empty string