### PR TITLE
ci: test against ActiveSupport::RedisCacheStore v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,11 +40,17 @@ jobs:
           - connection_pool_dalli
           - active_support_redis_cache_store
           - active_support_redis_cache_store_pooled
+          - active_support_5_redis_cache_store
+          - active_support_5_redis_cache_store_pooled
           - redis_store
         exclude:
           - gemfile: rack_1
             ruby: 3.2.2
           - gemfile: rails_5_2
+            ruby: 3.2.2
+          - gemfile: active_support_5_redis_cache_store
+            ruby: 3.2.2
+          - gemfile: active_support_5_redis_cache_store_pooled
             ruby: 3.2.2
           - gemfile: rails_4_2
             ruby: 3.2.2
@@ -53,6 +59,10 @@ jobs:
           - gemfile: rack_1
             ruby: 3.1.4
           - gemfile: rails_5_2
+            ruby: 3.1.4
+          - gemfile: active_support_5_redis_cache_store
+            ruby: 3.1.4
+          - gemfile: active_support_5_redis_cache_store_pooled
             ruby: 3.1.4
           - gemfile: rails_4_2
             ruby: 3.1.4
@@ -61,6 +71,10 @@ jobs:
           - gemfile: rack_1
             ruby: 3.0.6
           - gemfile: rails_5_2
+            ruby: 3.0.6
+          - gemfile: active_support_5_redis_cache_store
+            ruby: 3.0.6
+          - gemfile: active_support_5_redis_cache_store_pooled
             ruby: 3.0.6
           - gemfile: rails_4_2
             ruby: 3.0.6

--- a/Appraisals
+++ b/Appraisals
@@ -81,6 +81,17 @@ appraise "active_support_redis_cache_store_pooled" do
   gem "redis", "~> 5.0"
 end
 
+appraise "active_support_5_redis_cache_store" do
+  gem "activesupport", "~> 5.2.0"
+  gem "redis", "~> 5.0"
+end
+
+appraise "active_support_5_redis_cache_store_pooled" do
+  gem "activesupport", "~> 5.2.0"
+  gem "connection_pool", "~> 2.2"
+  gem "redis", "~> 5.0"
+end
+
 appraise "redis_store" do
   gem "redis-store", "~> 1.5"
 end

--- a/gemfiles/active_support_5_redis_cache_store.gemfile
+++ b/gemfiles/active_support_5_redis_cache_store.gemfile
@@ -2,7 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "railties", "~> 5.2.0"
+gem "activesupport", "~> 5.2.0"
+gem "redis", "~> 5.0"
 
 group :maintenance, optional: true do
   gem "bake"

--- a/gemfiles/active_support_5_redis_cache_store_pooled.gemfile
+++ b/gemfiles/active_support_5_redis_cache_store_pooled.gemfile
@@ -2,7 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "railties", "~> 5.2.0"
+gem "activesupport", "~> 5.2.0"
+gem "connection_pool", "~> 2.2"
+gem "redis", "~> 5.0"
 
 group :maintenance, optional: true do
   gem "bake"

--- a/gemfiles/active_support_redis_cache_store.gemfile
+++ b/gemfiles/active_support_redis_cache_store.gemfile
@@ -5,4 +5,9 @@ source "https://rubygems.org"
 gem "activesupport", "~> 6.1.0"
 gem "redis", "~> 5.0"
 
+group :maintenance, optional: true do
+  gem "bake"
+  gem "bake-gem"
+end
+
 gemspec path: "../"

--- a/gemfiles/active_support_redis_cache_store_pooled.gemfile
+++ b/gemfiles/active_support_redis_cache_store_pooled.gemfile
@@ -6,4 +6,9 @@ gem "activesupport", "~> 6.1.0"
 gem "connection_pool", "~> 2.2"
 gem "redis", "~> 5.0"
 
+group :maintenance, optional: true do
+  gem "bake"
+  gem "bake-gem"
+end
+
 gemspec path: "../"

--- a/gemfiles/connection_pool_dalli.gemfile
+++ b/gemfiles/connection_pool_dalli.gemfile
@@ -5,4 +5,9 @@ source "https://rubygems.org"
 gem "connection_pool", "~> 2.2"
 gem "dalli", "~> 3.0"
 
+group :maintenance, optional: true do
+  gem "bake"
+  gem "bake-gem"
+end
+
 gemspec path: "../"

--- a/gemfiles/dalli2.gemfile
+++ b/gemfiles/dalli2.gemfile
@@ -4,4 +4,9 @@ source "https://rubygems.org"
 
 gem "dalli", "~> 2.0"
 
+group :maintenance, optional: true do
+  gem "bake"
+  gem "bake-gem"
+end
+
 gemspec path: "../"

--- a/gemfiles/dalli3.gemfile
+++ b/gemfiles/dalli3.gemfile
@@ -4,4 +4,9 @@ source "https://rubygems.org"
 
 gem "dalli", "~> 3.0"
 
+group :maintenance, optional: true do
+  gem "bake"
+  gem "bake-gem"
+end
+
 gemspec path: "../"

--- a/gemfiles/rack_1.gemfile
+++ b/gemfiles/rack_1.gemfile
@@ -7,4 +7,9 @@ gem "activesupport", ">= 4.2"
 gem "rack", "~> 1.6"
 gem "rack-test", ">= 0.6"
 
+group :maintenance, optional: true do
+  gem "bake"
+  gem "bake-gem"
+end
+
 gemspec path: "../"

--- a/gemfiles/rack_2.gemfile
+++ b/gemfiles/rack_2.gemfile
@@ -3,6 +3,10 @@
 source "https://rubygems.org"
 
 gem "rack", "~> 2.0"
-gem "railties"
+
+group :maintenance, optional: true do
+  gem "bake"
+  gem "bake-gem"
+end
 
 gemspec path: "../"

--- a/gemfiles/rack_3.gemfile
+++ b/gemfiles/rack_3.gemfile
@@ -4,4 +4,9 @@ source "https://rubygems.org"
 
 gem "rack", "~> 3.0"
 
+group :maintenance, optional: true do
+  gem "bake"
+  gem "bake-gem"
+end
+
 gemspec path: "../"

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -5,4 +5,9 @@ source "https://rubygems.org"
 gem "railties", "~> 4.2.0"
 gem "rack-test", ">= 0.6"
 
+group :maintenance, optional: true do
+  gem "bake"
+  gem "bake-gem"
+end
+
 gemspec path: "../"

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -4,4 +4,9 @@ source "https://rubygems.org"
 
 gem "railties", "~> 6.0.0"
 
+group :maintenance, optional: true do
+  gem "bake"
+  gem "bake-gem"
+end
+
 gemspec path: "../"

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -4,4 +4,9 @@ source "https://rubygems.org"
 
 gem "railties", "~> 6.1.0"
 
+group :maintenance, optional: true do
+  gem "bake"
+  gem "bake-gem"
+end
+
 gemspec path: "../"

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -4,4 +4,9 @@ source "https://rubygems.org"
 
 gem "railties", "~> 7.0.0"
 
+group :maintenance, optional: true do
+  gem "bake"
+  gem "bake-gem"
+end
+
 gemspec path: "../"

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -4,4 +4,9 @@ source "https://rubygems.org"
 
 gem "railties", "~> 7.1.0"
 
+group :maintenance, optional: true do
+  gem "bake"
+  gem "bake-gem"
+end
+
 gemspec path: "../"

--- a/gemfiles/redis_4.gemfile
+++ b/gemfiles/redis_4.gemfile
@@ -4,4 +4,9 @@ source "https://rubygems.org"
 
 gem "redis", "~> 4.0"
 
+group :maintenance, optional: true do
+  gem "bake"
+  gem "bake-gem"
+end
+
 gemspec path: "../"

--- a/gemfiles/redis_5.gemfile
+++ b/gemfiles/redis_5.gemfile
@@ -4,4 +4,9 @@ source "https://rubygems.org"
 
 gem "redis", "~> 5.0"
 
+group :maintenance, optional: true do
+  gem "bake"
+  gem "bake-gem"
+end
+
 gemspec path: "../"

--- a/gemfiles/redis_store.gemfile
+++ b/gemfiles/redis_store.gemfile
@@ -4,4 +4,9 @@ source "https://rubygems.org"
 
 gem "redis-store", "~> 1.5"
 
+group :maintenance, optional: true do
+  gem "bake"
+  gem "bake-gem"
+end
+
 gemspec path: "../"


### PR DESCRIPTION
Add gemfile to prevent regressions in ActiveSupport 5 which is actively supported by `rack-attack`

Note:
- Changes in other gemfiles were done by Appraisals