### PR TITLE
ci: automatically run with latest ruby patch version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,12 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 3.2.2
-          - 3.1.4
-          - 3.0.6
-          - 2.7.8
-          - 2.6.10
-          - 2.5.8
+          - '3.2'
+          - '3.1'
+          - '3.0'
+          - '2.7'
+          - '2.6'
+          - '2.5'
         gemfile:
           - rack_3
           - rack_2
@@ -48,61 +48,61 @@ jobs:
           - redis_store
         exclude:
           - gemfile: rack_1
-            ruby: 3.2.2
+            ruby: '3.2'
           - gemfile: rails_5_2
-            ruby: 3.2.2
+            ruby: '3.2'
           - gemfile: active_support_5_redis_cache_store
-            ruby: 3.2.2
+            ruby: '3.2'
           - gemfile: active_support_5_redis_cache_store_pooled
-            ruby: 3.2.2
+            ruby: '3.2'
           - gemfile: dalli2
-            ruby: 3.2.2
+            ruby: '3.2'
           - gemfile: rack_1
-            ruby: 3.1.4
+            ruby: '3.1'
           - gemfile: rails_5_2
-            ruby: 3.1.4
+            ruby: '3.1'
           - gemfile: active_support_5_redis_cache_store
-            ruby: 3.1.4
+            ruby: '3.1'
           - gemfile: active_support_5_redis_cache_store_pooled
-            ruby: 3.1.4
+            ruby: '3.1'
           - gemfile: dalli2
-            ruby: 3.1.4
+            ruby: '3.1'
           - gemfile: rack_1
-            ruby: 3.0.6
+            ruby: '3.0'
           - gemfile: rails_5_2
-            ruby: 3.0.6
+            ruby: '3.0'
           - gemfile: active_support_5_redis_cache_store
-            ruby: 3.0.6
+            ruby: '3.0'
           - gemfile: active_support_5_redis_cache_store_pooled
-            ruby: 3.0.6
+            ruby: '3.0'
           - gemfile: dalli2
-            ruby: 3.0.6
+            ruby: '3.0'
           - gemfile: rack_1
-            ruby: 2.7.8
+            ruby: '2.7'
           - gemfile: rails_7_0
-            ruby: 2.6.10
+            ruby: '2.6'
           - gemfile: rails_7_0
-            ruby: 2.5.8
+            ruby: '2.5'
           - gemfile: active_support_7_0_redis_cache_store
-            ruby: 2.5.8
+            ruby: '2.6'
           - gemfile: active_support_7_0_redis_cache_store
-            ruby: 2.6.10
+            ruby: '2.5'
           - gemfile: active_support_7_0_redis_cache_store_pooled
-            ruby: 2.5.8
+            ruby: '2.6'
           - gemfile: active_support_7_0_redis_cache_store_pooled
-            ruby: 2.6.10
+            ruby: '2.5'
           - gemfile: rails_7_1
-            ruby: 2.6.10
+            ruby: '2.6'
           - gemfile: rails_7_1
-            ruby: 2.5.8
+            ruby: '2.5'
           - gemfile: active_support_7_1_redis_cache_store
-            ruby: 2.5.8
+            ruby: '2.6'
           - gemfile: active_support_7_1_redis_cache_store
-            ruby: 2.6.10
+            ruby: '2.5'
           - gemfile: active_support_7_1_redis_cache_store_pooled
-            ruby: 2.5.8
+            ruby: '2.6'
           - gemfile: active_support_7_1_redis_cache_store_pooled
-            ruby: 2.6.10
+            ruby: '2.5'
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:


### PR DESCRIPTION
With this change we don't need to care about patch versions

Note: I'm using strings as suggested in https://github.com/ruby/setup-ruby#supported-version-syntax. If you don't use the commas, most versions just work but `3.0` fails for some strange reason