### PR TITLE
System Hardening Phase 1: Catch errors at top level

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ See the [Backing & Hacking blog post](https://www.kickstarter.com/backing-and-ha
 - [Customizing responses](#customizing-responses)
   - [RateLimit headers for well-behaved clients](#ratelimit-headers-for-well-behaved-clients)
 - [Logging & Instrumentation](#logging--instrumentation)
+- [Custom Error Handling](#custom-error-handling)
 - [Testing](#testing)
 - [How it works](#how-it-works)
   - [About Tracks](#about-tracks)
@@ -400,11 +401,21 @@ ActiveSupport::Notifications.subscribe(/rack_attack/) do |name, start, finish, r
 end
 ```
 
+## Custom Error Handling
+
+You may specify the list of internal errors to allow (i.e. not raise an error)
+as either an array of Class and/or String values.
+
+```ruby
+# in initializers/rack_attack.rb
+Rack::Attack.allowed_errors += [MyErrorClass, 'MyOtherErrorClass']
+```
+
 ## Testing
 
-A note on developing and testing apps using Rack::Attack - if you are using throttling in particular, you will
-need to enable the cache in your development environment. See [Caching with Rails](http://guides.rubyonrails.org/caching_with_rails.html)
-for more on how to do this.
+When developing and testing apps using Rack::Attack, if you are using throttling in particular,
+you must enable the cache in your development environment. See
+[Caching with Rails](http://guides.rubyonrails.org/caching_with_rails.html) for how to do this.
 
 ### Disabling
 

--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -63,10 +63,10 @@ module Rack
       end
 
       def allow_error?(error)
-        allowed_errors&.any? do |ignored_error|
-          case ignored_error
-          when String then error.class.ancestors.any? {|a| a.name == ignored_error }
-          else error.is_a?(ignored_error)
+        allowed_errors&.any? do |allowed_error|
+          case allowed_error
+          when String then error.class.ancestors.any? {|a| a.name == allowed_error }
+          else error.is_a?(allowed_error)
           end
         end
       end

--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -32,13 +32,10 @@ module Rack
     autoload :Fail2Ban,             'rack/attack/fail2ban'
     autoload :Allow2Ban,            'rack/attack/allow2ban'
 
-    DEFAULT_ALLOWED_ERRORS = %w[Dalli::DalliError Redis::BaseError].freeze
-
     class << self
       attr_accessor :enabled,
                     :notifier,
-                    :throttle_discriminator_normalizer,
-                    :allowed_errors
+                    :throttle_discriminator_normalizer
 
       attr_reader :configuration
 
@@ -97,12 +94,11 @@ module Rack
         :safelists,
         :blocklists,
         :throttles,
-        :tracks
+        :tracks,
+        :allowed_errors,
+        :allowed_errors=
       )
     end
-
-    # Set class defaults
-    self.allowed_errors = DEFAULT_ALLOWED_ERRORS.dup
 
     # Set instance defaults
     @enabled = true

--- a/lib/rack/attack/configuration.rb
+++ b/lib/rack/attack/configuration.rb
@@ -5,6 +5,8 @@ require "ipaddr"
 module Rack
   class Attack
     class Configuration
+      DEFAULT_ALLOWED_ERRORS = %w[Dalli::DalliError Redis::BaseError].freeze
+
       DEFAULT_BLOCKLISTED_RESPONDER = lambda { |_req| [403, { 'content-type' => 'text/plain' }, ["Forbidden\n"]] }
 
       DEFAULT_THROTTLED_RESPONDER = lambda do |req|
@@ -19,10 +21,20 @@ module Rack
         end
       end
 
-      attr_reader :safelists, :blocklists, :throttles, :anonymous_blocklists, :anonymous_safelists
-      attr_accessor :blocklisted_responder, :throttled_responder, :throttled_response_retry_after_header
+      attr_reader :safelists,
+                  :blocklists,
+                  :throttles,
+                  :anonymous_blocklists,
+                  :anonymous_safelists
 
-      attr_reader :blocklisted_response, :throttled_response # Keeping these for backwards compatibility
+      attr_accessor :allowed_errors,
+                    :blocklisted_responder,
+                    :throttled_responder,
+                    :throttled_response_retry_after_header
+
+      # Keeping these for backwards compatibility
+      attr_reader :blocklisted_response,
+                  :throttled_response
 
       def blocklisted_response=(responder)
         warn "[DEPRECATION] Rack::Attack.blocklisted_response is deprecated. "\
@@ -116,6 +128,7 @@ module Rack
         @anonymous_blocklists = []
         @anonymous_safelists = []
         @throttled_response_retry_after_header = false
+        @allowed_errors = DEFAULT_ALLOWED_ERRORS.dup
 
         @blocklisted_responder = DEFAULT_BLOCKLISTED_RESPONDER
         @throttled_responder = DEFAULT_THROTTLED_RESPONDER

--- a/lib/rack/attack/store_proxy/dalli_proxy.rb
+++ b/lib/rack/attack/store_proxy/dalli_proxy.rb
@@ -24,34 +24,26 @@ module Rack
         end
 
         def read(key)
-          rescuing do
-            with do |client|
-              client.get(key)
-            end
+          with do |client|
+            client.get(key)
           end
         end
 
         def write(key, value, options = {})
-          rescuing do
-            with do |client|
-              client.set(key, value, options.fetch(:expires_in, 0), raw: true)
-            end
+          with do |client|
+            client.set(key, value, options.fetch(:expires_in, 0), raw: true)
           end
         end
 
         def increment(key, amount, options = {})
-          rescuing do
-            with do |client|
-              client.incr(key, amount, options.fetch(:expires_in, 0), amount)
-            end
+          with do |client|
+            client.incr(key, amount, options.fetch(:expires_in, 0), amount)
           end
         end
 
         def delete(key)
-          rescuing do
-            with do |client|
-              client.delete(key)
-            end
+          with do |client|
+            client.delete(key)
           end
         end
 
@@ -65,12 +57,6 @@ module Rack
               end
             end
           end
-        end
-
-        def rescuing
-          yield
-        rescue Dalli::DalliError
-          nil
         end
       end
     end

--- a/lib/rack/attack/store_proxy/redis_store_proxy.rb
+++ b/lib/rack/attack/store_proxy/redis_store_proxy.rb
@@ -11,14 +11,14 @@ module Rack
         end
 
         def read(key)
-          rescuing { get(key, raw: true) }
+          get(key, raw: true)
         end
 
         def write(key, value, options = {})
           if (expires_in = options[:expires_in])
-            rescuing { setex(key, expires_in, value, raw: true) }
+            setex(key, expires_in, value, raw: true)
           else
-            rescuing { set(key, value, raw: true) }
+            set(key, value, raw: true)
           end
         end
       end

--- a/rack-attack.gemspec
+++ b/rack-attack.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler", ">= 1.17", "< 3.0"
   s.add_development_dependency 'minitest', "~> 5.11"
   s.add_development_dependency "minitest-stub-const", "~> 0.6"
+  s.add_development_dependency 'rspec-mocks', '~> 3.11.0'
   s.add_development_dependency 'rack-test', "~> 2.0"
   s.add_development_dependency 'rake', "~> 13.0"
   s.add_development_dependency "rubocop", "1.12.1"

--- a/spec/acceptance/error_handling_spec.rb
+++ b/spec/acceptance/error_handling_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+describe "error handling" do
+
+  let(:store) do
+    ActiveSupport::Cache::MemoryStore.new
+  end
+
+  before do
+    Rack::Attack.cache.store = store
+
+    Rack::Attack.blocklist("fail2ban pentesters") do |request|
+      Rack::Attack::Fail2Ban.filter(request.ip, maxretry: 0, bantime: 600, findtime: 30) { true }
+    end
+  end
+
+  describe '.allowed_errors' do
+    before do
+      allow(store).to receive(:read).and_raise(RuntimeError)
+    end
+
+    it 'has default value' do
+      assert_equal Rack::Attack.allowed_errors, %w[Dalli::DalliError Redis::BaseError]
+    end
+
+    it 'can get and set value' do
+      Rack::Attack.allowed_errors = %w[Foobar]
+      assert_equal Rack::Attack.allowed_errors, %w[Foobar]
+    end
+
+    it 'can ignore error as Class' do
+      Rack::Attack.allowed_errors = [RuntimeError]
+
+      get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
+
+      assert_equal 200, last_response.status
+    end
+
+    it 'can ignore error ancestor as Class' do
+      Rack::Attack.allowed_errors = [StandardError]
+
+      get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
+
+      assert_equal 200, last_response.status
+    end
+
+    it 'can ignore error as String' do
+      Rack::Attack.allowed_errors = %w[RuntimeError]
+
+      get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
+
+      assert_equal 200, last_response.status
+    end
+
+    it 'can ignore error error ancestor as String' do
+      Rack::Attack.allowed_errors = %w[StandardError]
+
+      get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
+
+      assert_equal 200, last_response.status
+    end
+
+    it 'raises error if not ignored' do
+      assert_raises(RuntimeError) do
+        get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
+      end
+    end
+  end
+
+  describe '.allowed_errors?' do
+
+    it 'can match String or Class' do
+      Rack::Attack.allowed_errors = ['ArgumentError', RuntimeError]
+      assert Rack::Attack.allow_error?(ArgumentError.new)
+      assert Rack::Attack.allow_error?(RuntimeError.new)
+      refute Rack::Attack.allow_error?(StandardError.new)
+    end
+
+    it 'can match Class ancestors' do
+      Rack::Attack.allowed_errors = [StandardError]
+      assert Rack::Attack.allow_error?(ArgumentError.new)
+      refute Rack::Attack.allow_error?(Exception.new)
+    end
+
+    it 'can match String ancestors' do
+      Rack::Attack.allowed_errors = ['StandardError']
+      assert Rack::Attack.allow_error?(ArgumentError.new)
+      refute Rack::Attack.allow_error?(Exception.new)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 require "bundler/setup"
 
 require "minitest/autorun"
-require "minitest/pride"
+require "rspec/mocks/minitest_integration"
 require "rack/test"
 require "active_support"
 require "rack/attack"
@@ -35,6 +35,7 @@ class Minitest::Spec
   after do
     Rack::Attack.clear_configuration
     Rack::Attack.instance_variable_set(:@cache, nil)
+    Rack::Attack.allowed_errors = Rack::Attack::DEFAULT_ALLOWED_ERRORS.dup
   end
 
   def app

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,7 @@ class Minitest::Spec
   after do
     Rack::Attack.clear_configuration
     Rack::Attack.instance_variable_set(:@cache, nil)
-    Rack::Attack.allowed_errors = Rack::Attack::DEFAULT_ALLOWED_ERRORS.dup
+    Rack::Attack.allowed_errors = Rack::Attack::Configuration::DEFAULT_ALLOWED_ERRORS.dup
   end
 
   def app


### PR DESCRIPTION
In PR https://github.com/rack/rack-attack/pull/577, @grzuy asked me to break it into a series of smaller PRs.

My plan is as follows:
- [x] **This PR**:
   - [x] Move error catching to top-level of `Rack::Attack`. This is mandatory to do, because we need to have Rack::Attack be aware of errors in order to implement advanced error handling/fault-tolerance mechanisms in subsequent PRs.
   - [x] Remove the `rescuing` blocks from `Dalli/RedisProxy` classes.
   - [x] Add "Rack::Attack.allowed_errors" config which defaults to `Dalli::DalliError` and `Redis::BaseError`. This config is useful if you are implementing a custom store class.

Future PRs (will raise the next one after this one is merged)

- [ ] PR 2:
  - [ ] Add Rack::Attack.error_handler which takes a Proc for custom error handling.
  - [ ] Refactor Rack::Attack a bit so the error_handler can select whether to throttle or block.
- [ ] PR 3: Add Rack::Attack.calling? so Rails Cache error hander can raise its error for Rack::Attack.
- [ ] PR 4: Add Rack::Attack.failure_cooldown config. This temporarily disables Rack::Attack after an error occurs (including allowed errors), to prevent cache connection latency.

---

Note: This PR will affect the small number of users are directly using the `Dalli/RedisProxy` classes (or subclassing them, etc.) since the methods of these classes now raise `Dalli::DalliError` /`Redis::BaseError` rather than returning `nil`. It should probably be released as a major version for this reason.