### PR TITLE
Add dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Opened this PR based on https://github.com/rack/rack-attack/pull/642#pullrequestreview-1795979481

using the [example config](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#example-dependabotyml-file-for-github-actions) which seems appropriate for our case

so that GitHub Actions get automatically checked by dependabot on a weekly basis and open PRs with upgrades if applicable.