### PR TITLE
Make it possible to block requests based on response.

### DIFF
--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -31,6 +31,7 @@ module Rack
     autoload :Track,                'rack/attack/track'
     autoload :Fail2Ban,             'rack/attack/fail2ban'
     autoload :Allow2Ban,            'rack/attack/allow2ban'
+    autoload :Postrequest,          'rack/attack/postrequest'
 
     class << self
       attr_accessor :enabled, :notifier, :throttle_discriminator_normalizer
@@ -81,6 +82,7 @@ module Rack
         :clear_configuration,
         :safelists,
         :blocklists,
+        :postrequest,
         :throttles,
         :tracks
       )
@@ -126,7 +128,9 @@ module Rack
         end
       else
         configuration.tracked?(request)
-        @app.call(env)
+        response = @app.call(env)
+        configuration.process_postrequests(request, response)
+        response
       end
     end
   end

--- a/lib/rack/attack/postrequest.rb
+++ b/lib/rack/attack/postrequest.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Rack
+  class Attack
+    class Postrequest < Check
+      def initialize(name = nil, &block)
+        super
+        @type = :postrequest
+      end
+
+      def matched_by?(request, response)
+        block.call(request, response).tap do |match|
+          if match
+            request.env["rack.attack.matched"] = name
+            request.env["rack.attack.match_type"] = type
+            Rack::Attack.instrument(request)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/postrequest_spec.rb
+++ b/spec/acceptance/postrequest_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+require "timecop"
+
+describe "postrequest" do
+  before do
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+
+    Rack::Attack.postrequest("fail2ban for 404") do |request, response|
+      Rack::Attack::Fail2Ban.filter(request.ip, maxretry: 2, findtime: 30, bantime: 60) do
+        if response.nil?
+          false
+        else
+          response[0] == 404
+        end
+      end
+    end
+  end
+
+  it "returns OK for many requests with 200 status" do
+    get "/"
+    assert_equal 200, last_response.status
+
+    get "/"
+    assert_equal 200, last_response.status
+  end
+
+
+  it "returns OK for few requests with 404 status" do
+    get "/not_found"
+    assert_equal 404, last_response.status
+
+    get "/not_found"
+    assert_equal 404, last_response.status
+  end
+
+  it "forbids all access after reaching maxretry limit" do
+    get "/not_found"
+    assert_equal 404, last_response.status
+
+    get "/not_found"
+    assert_equal 404, last_response.status
+
+    get "/not_found"
+    assert_equal 403, last_response.status
+
+    get "/"
+    assert_equal 403, last_response.status
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,13 @@ class Minitest::Spec
       use Rack::Attack
       use Rack::Lint
 
-      run lambda { |_env| [200, {}, ['Hello World']] }
+      run lambda { |env|
+        if env['PATH_INFO'] == '/not_found'
+          [404, {}, ['Not Found']]
+        else
+          [200, {}, ['Hello World']]
+        end
+      }
     end.to_app
   end
 


### PR DESCRIPTION
I want to use rack-attack to block pentesters based on 4xx requests. It's not possible with the current gem API. 

So here is a POC how it might look like:

```ruby
    Rack::Attack.postrequest("fail2ban for 404") do |request, response|
      Rack::Attack::Fail2Ban.filter(request.ip, maxretry: 2, findtime: 30, bantime: 60) do
        if response.nil?
          false
        else
          response[0] == 404
        end
      end
    end
```

It might look clumsy, but you have to check if a response exists with such API. 

So, I'm ready to add more specs and finish this to get it ready to merge if you think this is a good idea.

Naming is also debatable.