### PR TITLE
Allow using middleware with custom configuration

### DIFF
--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -96,9 +96,9 @@ module Rack
 
     attr_reader :configuration
 
-    def initialize(app)
+    def initialize(app, configuration = nil)
       @app = app
-      @configuration = self.class.configuration
+      @configuration = configuration || self.class.configuration
     end
 
     def call(env)


### PR DESCRIPTION
So far, the documentation is suggesting 100% global configuration for what's essentially a middleware. I do wonder whether there are any reasons not to support passing in a configuration directly wherever I am adding a middleware to my stack. (This could be a base controller with per-controller middleware.)

Pseudo-code example:

```ruby
config = Rack::Attack::Configuration.new.tap do
  _1.throttle("my_api.throttle_per_minute", limit: 20,  period: 1.minute, &:ip)
  _1.throttle("my_api.throttle_per_hour",   limit: 100, period: 1.hour,   &:ip)
end

use Rack::Attack, config
```

Primarily, this would let me avoid mixing filters (for request type and path) with the discriminator block - I'd rather keep the filtering to my middleware builder.

Let me know what you think about this idea, and especially what may speak against this. Then I'm happy to send a "real" pull request with tests etc.