### PR TITLE
ci: Don't fail fast

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
         ports:
           - 11211:11211
     strategy:
+      fail-fast: false
       matrix:
         ruby:
           - '3.3'


### PR DESCRIPTION
There is no reason why we want to fail fast on the CI.

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast