### PR TITLE
Refactor notifications checks in tests

### DIFF
--- a/spec/acceptance/blocking_subnet_spec.rb
+++ b/spec/acceptance/blocking_subnet_spec.rb
@@ -3,6 +3,8 @@
 require_relative "../spec_helper"
 
 describe "Blocking an IP subnet" do
+  let(:notifications) { [] }
+
   before do
     Rack::Attack.blocklist_ip("1.2.3.4/31")
   end
@@ -26,21 +28,18 @@ describe "Blocking an IP subnet" do
   end
 
   it "notifies when the request is blocked" do
-    notified = false
-    notification_type = nil
-
     ActiveSupport::Notifications.subscribe("blocklist.rack_attack") do |_name, _start, _finish, _id, payload|
-      notified = true
-      notification_type = payload[:request].env["rack.attack.match_type"]
+      notifications.push(payload)
     end
 
     get "/", {}, "REMOTE_ADDR" => "5.6.7.8"
 
-    refute notified
+    assert notifications.empty?
 
     get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
 
-    assert notified
-    assert_equal :blocklist, notification_type
+    assert_equal 1, notifications.size
+    notification = notifications.pop
+    assert_equal :blocklist, notification[:request].env["rack.attack.match_type"]
   end
 end

--- a/spec/acceptance/safelisting_ip_spec.rb
+++ b/spec/acceptance/safelisting_ip_spec.rb
@@ -3,6 +3,8 @@
 require_relative "../spec_helper"
 
 describe "Safelist an IP" do
+  let(:notifications) { [] }
+
   before do
     Rack::Attack.blocklist("admin") do |request|
       request.path == "/admin"
@@ -42,15 +44,15 @@ describe "Safelist an IP" do
   end
 
   it "notifies when the request is safe" do
-    notification_type = nil
-
     ActiveSupport::Notifications.subscribe("safelist.rack_attack") do |_name, _start, _finish, _id, payload|
-      notification_type = payload[:request].env["rack.attack.match_type"]
+      notifications.push(payload)
     end
 
     get "/admin", {}, "REMOTE_ADDR" => "5.6.7.8"
 
     assert_equal 200, last_response.status
-    assert_equal :safelist, notification_type
+    assert_equal 1, notifications.size
+    notification = notifications.pop
+    assert_equal :safelist, notification[:request].env["rack.attack.match_type"]
   end
 end

--- a/spec/acceptance/track_spec.rb
+++ b/spec/acceptance/track_spec.rb
@@ -3,27 +3,26 @@
 require_relative "../spec_helper"
 
 describe "#track" do
+  let(:notifications) { [] }
+
   it "notifies when track block returns true" do
     Rack::Attack.track("ip 1.2.3.4") do |request|
       request.ip == "1.2.3.4"
     end
 
-    notification_matched = nil
-    notification_type = nil
-
     ActiveSupport::Notifications.subscribe("track.rack_attack") do |_name, _start, _finish, _id, payload|
-      notification_matched = payload[:request].env["rack.attack.matched"]
-      notification_type = payload[:request].env["rack.attack.match_type"]
+      notifications.push(payload)
     end
 
     get "/", {}, "REMOTE_ADDR" => "5.6.7.8"
 
-    assert_nil notification_matched
-    assert_nil notification_type
+    assert notifications.empty?
 
     get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
 
-    assert_equal "ip 1.2.3.4", notification_matched
-    assert_equal :track, notification_type
+    assert_equal 1, notifications.size
+    notification = notifications.pop
+    assert_equal "ip 1.2.3.4", notification[:request].env["rack.attack.matched"]
+    assert_equal :track, notification[:request].env["rack.attack.match_type"]
   end
 end

--- a/spec/acceptance/track_throttle_spec.rb
+++ b/spec/acceptance/track_throttle_spec.rb
@@ -4,6 +4,8 @@ require_relative "../spec_helper"
 require "timecop"
 
 describe "#track with throttle-ish options" do
+  let(:notifications) { [] }
+
   it "notifies when throttle goes over the limit without actually throttling requests" do
     Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
 
@@ -11,43 +13,35 @@ describe "#track with throttle-ish options" do
       request.ip
     end
 
-    notification_matched = nil
-    notification_type = nil
-
     ActiveSupport::Notifications.subscribe("track.rack_attack") do |_name, _start, _finish, _id, payload|
-      notification_matched = payload[:request].env["rack.attack.matched"]
-      notification_type = payload[:request].env["rack.attack.match_type"]
+      notifications.push(payload)
     end
 
     get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
 
-    assert_nil notification_matched
-    assert_nil notification_type
+    assert notifications.empty?
 
     assert_equal 200, last_response.status
 
     get "/", {}, "REMOTE_ADDR" => "5.6.7.8"
 
-    assert_nil notification_matched
-    assert_nil notification_type
+    assert notifications.empty?
 
     assert_equal 200, last_response.status
 
     get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
 
-    assert_equal "by ip", notification_matched
-    assert_equal :track, notification_type
+    assert_equal 1, notifications.size
+    notification = notifications.pop
+    assert_equal "by ip", notification[:request].env["rack.attack.matched"]
+    assert_equal :track, notification[:request].env["rack.attack.match_type"]
 
     assert_equal 200, last_response.status
 
     Timecop.travel(60) do
-      notification_matched = nil
-      notification_type = nil
-
       get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
 
-      assert_nil notification_matched
-      assert_nil notification_type
+      assert notifications.empty?
 
       assert_equal 200, last_response.status
     end


### PR DESCRIPTION
- Unify how notifications are tracked and checked using `Array`'s `#push` `#pop` and `#size`.
- With this now we not only check "some notification happened" but the exact amount of notifications since in some cases we might trigger more than once, so this can prevent missing or mixing notifications.

Note: We could introduce a custom class built on top of Array with some facilities but seems to not be worth it at the time