### PR TITLE
[BUG] Add tracks attr_reader to Configuration

### DIFF
--- a/lib/rack/attack/configuration.rb
+++ b/lib/rack/attack/configuration.rb
@@ -19,7 +19,7 @@ module Rack
         end
       end
 
-      attr_reader :safelists, :blocklists, :throttles, :anonymous_blocklists, :anonymous_safelists
+      attr_reader :safelists, :blocklists, :throttles, :tracks, :anonymous_blocklists, :anonymous_safelists
       attr_accessor :blocklisted_responder, :throttled_responder, :throttled_response_retry_after_header
 
       attr_reader :blocklisted_response, :throttled_response # Keeping these for backwards compatibility

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+describe Rack::Attack::Configuration do
+  subject { Rack::Attack::Configuration.new }
+
+  describe 'attributes' do
+    it 'exposes the safelists attribute' do
+      _(subject.safelists).must_equal({})
+    end
+
+    it 'exposes the blocklists attribute' do
+      _(subject.blocklists).must_equal({})
+    end
+
+    it 'exposes the throttles attribute' do
+      _(subject.throttles).must_equal({})
+    end
+
+    it 'exposes the tracks attribute' do
+      _(subject.tracks).must_equal({})
+    end
+
+    it 'exposes the anonymous_blocklists attribute' do
+      _(subject.anonymous_blocklists).must_equal([])
+    end
+
+    it 'exposes the anonymous_safelists attribute' do
+      _(subject.anonymous_safelists).must_equal([])
+    end
+  end
+end


### PR DESCRIPTION
**Description**:
This pull request adds the missing `tracks` attribute reader to the `Rack::Attack::Configuration` class. This change ensures that the `tracks` attribute is accessible, consistent with other attributes such as `safelists`, `blocklists`, and `throttles`.

**How this was discovered?**
```
> Rack::Attack.tracks.clear
=> warning: #<Class:Rack::Attack>#tracks at /.rbenv/versions/3.1.3/lib/ruby/3.1.0/forwardable.rb:157 forwarding to private method Rack::Attack::Configuration#tracks
/.rbenv/versions/3.1.3/lib/ruby/3.1.0/forwardable.rb:236:in `tracks': undefined method `tracks' for #<Rack::Attack::Configuration:0x000000010c09e978...
```

**Changes**:
- Added `:tracks` to the `attr_reader` in `lib/rack/attack/configuration.rb`.
- Updated `spec/configuration_spec.rb` to include tests for the `tracks` attribute alongside `safelists`, `blocklists`, and `throttles`.

**Testing**:
- Verified that all existing tests pass.
- Added new tests to check the accessibility of the `tracks` attribute.

This update enhances the completeness and consistency of the `Rack::Attack::Configuration` class, ensuring that all attributes are properly exposed and tested.