### PR TITLE
Remove CodeClimate

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ See the [Backing & Hacking blog post](https://www.kickstarter.com/backing-and-ha
 
 [![Gem Version](https://badge.fury.io/rb/rack-attack.svg)](https://badge.fury.io/rb/rack-attack)
 [![build](https://github.com/rack/rack-attack/actions/workflows/build.yml/badge.svg)](https://github.com/rack/rack-attack/actions/workflows/build.yml)
-[![Code Climate](https://codeclimate.com/github/kickstarter/rack-attack.svg)](https://codeclimate.com/github/kickstarter/rack-attack)
 [![Join the chat at https://gitter.im/rack-attack/rack-attack](https://badges.gitter.im/rack-attack/rack-attack.svg)](https://gitter.im/rack-attack/rack-attack)
 
 ## Table of contents


### PR DESCRIPTION
CodeClimate doesn't exist anymore. We may want to consider to install qlty.sh which is the successor of CodeClimate.

https://qlty.sh/gh/rack/projects/rack-attack